### PR TITLE
made blog cards clickable

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -54,6 +54,7 @@ console.log(getFirebase())
       <main>
       {blogPosts.map(blogPost => (
         <section key={blogPost.slug} className="card">
+        <Link to={`/${blogPost.slug}`}>
           <img src={blogPost.coverImage} alt={blogPost.coverImageAlt} />
           <div className="card-content">
             <h2>
@@ -67,6 +68,7 @@ console.log(getFirebase())
             ></p>
             <Link to={`/${blogPost.slug}`}>Continue reading...</Link>
           </div>
+          </Link>
         </section>
       ))}
       </main>


### PR DESCRIPTION
Problem:
there was a link on each card representing a post, but the card itself could not be clicked at all.

Solution:
added a link tag to the card so that both the `continue reading` and the whole card would lead to the article